### PR TITLE
BUG: fix repositories array

### DIFF
--- a/packages/automation/generate_nominees.js
+++ b/packages/automation/generate_nominees.js
@@ -143,8 +143,17 @@ glob(path.join(npath, '/*.json'), {}, async (err, files) => {
     let n = JSON.parse(fs.readFileSync(files[i], 'utf8'));
 
     let html = '';
-    if(n.hasOwnProperty('repositoryURL')){
-      var matchGithub = n.repositoryURL.match(/https:\/\/github.com\/([^\/]*)\/([^\/]*)/);
+    if(n.hasOwnProperty('repositories')){
+      let repoIndex = 0;
+      if(n.repositories.length > 1) {
+        for(item in n.repositories) {
+          if(n.repositories[item].name === 'main'){
+            repoIndex = item
+            break
+          }
+        }
+      }
+      var matchGithub = n.repositories[repoIndex].url.match(/https:\/\/github.com\/([^\/]*)\/([^\/]*)/);
       if(matchGithub){
         html += await fetchGithubActivity(matchGithub[1], matchGithub[2]);
       }


### PR DESCRIPTION
Propagates the changes introduced in DPGAlliance/publicgoods-candidates#924 where `repositoryURL` is replaced with array `repositories`  of objects containing properties `name` and `url`.

The logic checks first if properties `repositories` exist.
If it exists, checks if the array contains more than one item. If it does not, it will take the first item.
If it contains more than one item, it searches for the item named 'main'.

Cc: @nathanbaleeta 