### PR TITLE
BUG: fix processing of repositoryURL

### DIFF
--- a/packages/registry/src/index.js
+++ b/packages/registry/src/index.js
@@ -241,8 +241,17 @@ function ListItem(props){
 
   if(item.hasOwnProperty('website') && item.website !== '') {
       name = <a href={item.website} target="_blank" rel="noopener noreferrer">{nameText}</a>;
-  } else if(item.hasOwnProperty('repositoryURL') && item.repositoryURL !== '') {
-      name = <a href={item.repositoryURL} target="_blank" rel="noopener noreferrer">{nameText}</a>;
+  } else if(item.hasOwnProperty('repositories') && item.repositories.length) {
+      let repoIndex = 0;
+      if(item.repositories.length > 1) {
+        for(let i in item.repositories) {
+          if(item.repositories[i].name === 'main'){
+            repoIndex = i
+            break
+          }
+        }
+      }
+      name = <a href={item.repositories[repoIndex].url} target="_blank" rel="noopener noreferrer">{nameText}</a>;
   } else {
       name = {nameText}
   }


### PR DESCRIPTION
Continues the work started in #96, In the first PR we modified the logic for how `nominees.json` is generated which is used to populate the registry. In this PR, we tackle the actual HTML code generation of the registry, accounting for the property name change. Local tests now indicate that the registry is finally restored.

Cc: @nathanbaleeta 