### PR TITLE
[MAINT] Rename table header titles

### DIFF
--- a/packages/registry/src/index.js
+++ b/packages/registry/src/index.js
@@ -307,8 +307,8 @@ class List extends Component {
             <tr>
               <th>Name</th>
               <th>Description</th>
-              <th>License</th>
-              <th>Past year of activity</th>
+              <th>Open license</th>
+              <th>Activity</th>
             </tr>
           </thead>
           <tbody>


### PR DESCRIPTION
This PR renames the website registry table header titles as follows:

- `License` to `Open license`
- `Past year activity` to `Activity`