### PR TITLE
BUG: fix empty repo list

### DIFF
--- a/packages/automation/generate_nominees.js
+++ b/packages/automation/generate_nominees.js
@@ -152,11 +152,11 @@ glob(path.join(npath, '/*.json'), {}, async (err, files) => {
             break
           }
         }
-      }
-      var matchGithub = n.repositories[repoIndex].url.match(/https:\/\/github.com\/([^\/]*)\/([^\/]*)/);
-      if(matchGithub){
-        html += await fetchGithubActivity(matchGithub[1], matchGithub[2]);
-      }
+        var matchGithub = n.repositories[repoIndex].url.match(/https:\/\/github.com\/([^\/]*)\/([^\/]*)/);
+        if(matchGithub){
+          html += await fetchGithubActivity(matchGithub[1], matchGithub[2]);
+        }
+      }  
     }
     n['githubActivity'] = html;
     if(n['stage'] === 'DPG' && fs.existsSync(path.join(spath, path.basename(files[i])))) {


### PR DESCRIPTION
This PR fixes a bug first detected in the build of merging of DPGAlliance/publicgoods-candidates#958 triggered by an empty array in `repositories=[]`. The code to search for the repo should only run if these two conditionals are met:
- L146 `if(n.hasOwnProperty('repositories')){`
- L148 `if(n.repositories.length > 1) {`

Thus, the `match` and `fetchGithubActivity` are moved inside the last conditional above.

Please note that if either of the `if`s don't pass, `html` var defined in L145 is empty, and is assigned as an empty value in L161, which is the desired behavior