### PR TITLE
Updated project name url to point to DPG website

### DIFF
--- a/packages/registry/src/index.js
+++ b/packages/registry/src/index.js
@@ -239,25 +239,14 @@ function ListItem(props){
     nameText = item.name;
   }
 
-  if(item.hasOwnProperty('website') && item.website !== '') {
-      name = <a href={item.website} target="_blank" rel="noopener noreferrer">{nameText}</a>;
-  } else if(item.hasOwnProperty('repositories') && item.repositories.length) {
-      let repoIndex = 0;
-      if(item.repositories.length > 1) {
-        for(let i in item.repositories) {
-          if(item.repositories[i].name === 'main'){
-            repoIndex = i
-            break
-          }
-        }
-      }
-      name = <a href={item.repositories[repoIndex].url} target="_blank" rel="noopener noreferrer">{nameText}</a>;
-  } else {
-      name = {nameText}
-  }
-
   if(item.stage === 'DPG') {
     if(item.dpgLink){
+        name = <a href={'/registry/' + item.name.normalize('NFD')
+        .toLowerCase()
+        .replace(/\s{2,}/g, ' ')
+        .replace(/ /g, '-')
+        .replace(/[^A-Za-z0-9-.]/g, '')
+        .replace(/-{2,}/g, '-') +'.html'} target="_blank" rel="noopener noreferrer">{nameText}</a>;
       name = <span>{name} <a href={'/registry/' + item.name.normalize('NFD')
                                                            .toLowerCase()
                                                            .replace(/\s{2,}/g, ' ')
@@ -267,6 +256,24 @@ function ListItem(props){
     } else {
       name = <span>{name} <a href="/blog/announcing-the-first-vetted-digital-public-goods-for-foundational-literacy-and-early-grade-reading/"><img src="dpgicon.svg" alt="DPG icon" height="25"/></a></span>;
     }
+  }
+  else{
+    if(item.hasOwnProperty('website') && item.website !== '') {
+        name = <a href={item.website} target="_blank" rel="noopener noreferrer">{nameText}</a>;
+      } else if(item.hasOwnProperty('repositories') && item.repositories.length) {
+          let repoIndex = 0;
+          if(item.repositories.length > 1) {
+            for(let i in item.repositories) {
+              if(item.repositories[i].name === 'main'){
+                repoIndex = i
+                break
+              }
+            }
+          }
+          name = <a href={item.repositories[repoIndex].url} target="_blank" rel="noopener noreferrer">{nameText}</a>;
+      } else {
+          name = {nameText}
+      }
   }
 
   let itemClass='';


### PR DESCRIPTION
This PR fixes #131 and reveals a potential bug in the [generate_dpgs.js](https://github.com/DPGAlliance/publicgoods-scripts/blob/main/packages/automation/generate_dpgs.js) script. cc @lacabra 

Upon testing locally, I realized that the individual pages were not being properly generated because the [template used for the pages](https://github.com/DPGAlliance/publicgoods-website/blob/main/registry/index.html) did not have the word `Placeholder`.
this `Placeholder` keyword is what the code looks for to replace the content of the template.

Unless I am missing something, I would suggest that the template be fixed in the `publicgoods-website` repo by adding the `Placeholder` keyword before pushing this PR.

I have been wondering why this has not shown up earlier (again, unless I'm missing something)
#helpNeeded