### PR TITLE
Update quizQuestions.js

### DIFF
--- a/packages/eligibility/src/api/quizQuestions.js
+++ b/packages/eligibility/src/api/quizQuestions.js
@@ -49,7 +49,7 @@ var quizQuestions = [
                   }
                 ],
         name: "open license",
-        link: "https://github.com/DPGAlliance/publicgoods-candidates/blob/master/docs/licenses.md"
+        link: "https://github.com/DPGAlliance/publicgoods-candidates/blob/main/help-center/licenses.md"
       }
   },
   {


### PR DESCRIPTION
Fix for outdated link to approved open licenses.

Related to [this PR](https://github.com/DPGAlliance/DPG-Standard/pull/144) on the DPG Standard repository.