### PR TITLE
Data explorer refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ typings/
 **/map/public/templateClassName.txt
 .DS_Store
 rebuild.bash
+registryIndex.html
+wget-log

--- a/packages/automation/index.js
+++ b/packages/automation/index.js
@@ -73,10 +73,10 @@ let combos = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 // Initialize SDG array to count occurences in candidates
 let sdgs = new Array(17).fill(0);
 // Initialize type array to count occurences in candidates
-const TYPE1 = "Open software";
-const TYPE2 = "Open data";
-const TYPE3 = "Open standard";
-const TYPE4 = "Open content";
+const TYPE1 = "Open Software";
+const TYPE2 = "Open Data";
+const TYPE3 = "Open Standard";
+const TYPE4 = "Open Content";
 let types = {};
 types[TYPE1] = 0;
 types[TYPE2] = 0;
@@ -86,22 +86,22 @@ let vettedDPGs = 0;
 
 // Iterate over candidates, and over each nested array and count
 candidates.forEach(function (e) {
-  /* if (!e["sdgs"]) {
-    console.log(e)
-  } */
   if (e["sdgs"]) {
     e["sdgs"].forEach(function (d) {
       let goalString = SDGS.find((goal,index)=>goal.includes(d.sdg.substring(3,5)))
       let sdgNumber = SDGS.indexOf(goalString);
-      //console.log(d.sdg+" The SDG number is ", sdgNumber)
-      //sdgs[d["SDGNumber"] - 1]++;
+      
       sdgs[sdgNumber]++;
 
     });
-    console.log(sdgs)
     if (e["categories"]) {
       e["categories"].forEach(function (d) {
-        types[d]++;
+        if(types.hasOwnProperty(d)){
+          types[d]++;
+        }
+        else{
+          types[d]=0
+        }
       });
       
       if (

--- a/packages/automation/index.js
+++ b/packages/automation/index.js
@@ -1,160 +1,279 @@
-const fs = require('fs');
-const glob = require('glob');
-const replace = require('replace-in-file');
+const fs = require("fs");
+const glob = require("glob");
+const replace = require("replace-in-file");
 const cheerio = require("cheerio");
 const fetch = require("node-fetch");
 
-const SDGS = ['No Poverty',
-              'Zero Hunger',
-              'Good Health and Well-being',
-              'Quality Education',
-              'Gender Equality',
-              'Clean Water and Sanitation',
-              'Affordable and Clean Energy',
-              'Decent Work and Economic Growth',
-              'Industry, Innovation and Infrastructure',
-              'Reduced Inequality',
-              'Sustainable Cities and Communities',
-              'Responsible Consumption and Production',
-              'Climate Action',
-              'Life Below Water',
-              'Life on Land',
-              'Peace and Justice Strong Institutions',
-              'Partnerships to achieve the Goal']
+const fspromise = require("fs/promises");
+let dpgs = [];
+try {
+  dpgs = JSON.parse(fs.readFileSync("../registry/src/nominees.json", "utf8"));
+} catch (err) {
+  console.error(err);
+}
 
-const sdgColors = ['#E5243B',
-                   '#DDA63A',
-                   '#4C9F38',
-                   '#C5192D',
-                   '#FF3A21',
-                   '#26BDE2',
-                   '#FCC30B',
-                   '#A21942',
-                   '#FD6925',
-                   '#DD1367',
-                   '#FD9D24',
-                   '#BF8B2E',
-                   '#3F7E44',
-                   '#0A97D9',
-                   '#56C02B',
-                   '#00689D',
-                   '#19486A']
+//console.log(dpgs[2])
+const SDGS = [
+  "SDG1: End Poverty in all its forms everywhere",
+  "SDG2: Zero Hunger",
+  "SDG3: Good Health and Well-Being",
+  "SDG4: Quality Education",
+  "SDG5: Gender Equity",
+  "SDG6: Clean Water and Sanitation",
+  "SDG7: Affordable and Clean Energy",
+  "SDG8: Decent Work and Economic Growth",
+  "SDG9: Industry, Innovation and Infrastructure",
+  "SDG10: Reduced Inequality",
+  "SDG11: Sustainable Cities and Communities",
+  "SDG12: Responsible Consumption and Production",
+  "SDG13: Climate Action",
+  "SDG14: Life Below Water",
+  "SDG15: Life on Land",
+  "SDG16: Peace and Justice Strong Institutions",
+  "SDG17: Partnerships to achieve the Goal",
+];
 
-path = '../../../publicgoods-candidates/nominees'
-pathHtml = '../../../publicgoods-website/registry/index.html';
-destHtml = '../registry/public/index.html';
-pathFormHtml = '../../../publicgoods-website/eligibility/index.html';
-destFormHtml = '../eligibility/public/index.html';
-pathMapHtml = '../../../publicgoods-website/map/index.html'
-destMapHtml = '../map/public/';
-pathRoadmapHtml = '../../../publicgoods-website/roadmap/index.html';
-destRoadmapHtml = '../roadmap/public/index.html';
+const sdgColors = [
+  "#E5243B",
+  "#DDA63A",
+  "#4C9F38",
+  "#C5192D",
+  "#FF3A21",
+  "#26BDE2",
+  "#FCC30B",
+  "#A21942",
+  "#FD6925",
+  "#DD1367",
+  "#FD9D24",
+  "#BF8B2E",
+  "#3F7E44",
+  "#0A97D9",
+  "#56C02B",
+  "#00689D",
+  "#19486A",
+];
 
+path = "../../../publicgoods-candidates/nominees";
+pathHtml = "../../../publicgoods-website/registry/index.html";
+destHtml = "../registry/public/index.html";
+pathFormHtml = "../../../publicgoods-website/eligibility/index.html";
+destFormHtml = "../eligibility/public/index.html";
+pathMapHtml = "../../../publicgoods-website/map/index.html";
+destMapHtml = "../map/public/";
+pathRoadmapHtml = "../../../publicgoods-website/roadmap/index.html";
+destRoadmapHtml = "../roadmap/public/index.html";
 
 function sleep(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
-  
-let candidates=[];
 
-glob(path + '/*.json', {}, async (err, files) => {
-  for (var i=0; i<files.length; i++) {
-    candidates.push(JSON.parse(fs.readFileSync(files[i], 'utf8')));
-  }
-  let combos = [0,0,0,0,0,0,0,0,0,0,0,0,0,0]
-  // Initialize SDG array to count occurences in candidates
-  let sdgs = new Array(17).fill(0);
-  // Initialize type array to count occurences in candidates
-  const TYPE1='software';
-  const TYPE2='data';
-  const TYPE3='standard';
-  const TYPE4='content';
-  let types = {};
-  types[TYPE1]=0;
-  types[TYPE2]=0;
-  types[TYPE3]=0;
-  types[TYPE4]=0;
-  let vettedDPGs = 0;
-  // Iterate over candidates, and over each nested array and count
-  candidates.forEach(function(e) {
-    e['SDGs'].forEach(function(d){
-      sdgs[d['SDGNumber']-1]++;
-    })
-    e['type'].forEach(function(d){
-      types[d]++;
-    })
-    if     ( e['type'].includes(TYPE1) && !e['type'].includes(TYPE2) && !e['type'].includes(TYPE3) && !e['type'].includes(TYPE4)){ combos[0]++;}
-    else if(!e['type'].includes(TYPE1) &&  e['type'].includes(TYPE2) && !e['type'].includes(TYPE3) && !e['type'].includes(TYPE4)){ combos[1]++;}
-    else if(!e['type'].includes(TYPE1) && !e['type'].includes(TYPE2) &&  e['type'].includes(TYPE3) && !e['type'].includes(TYPE4)){ combos[2]++;}
-    else if( e['type'].includes(TYPE1) &&  e['type'].includes(TYPE2) && !e['type'].includes(TYPE3) && !e['type'].includes(TYPE4)){ combos[3]++;}
-    else if( e['type'].includes(TYPE1) && !e['type'].includes(TYPE2) &&  e['type'].includes(TYPE3) && !e['type'].includes(TYPE4)){ combos[4]++;}
-    else if(!e['type'].includes(TYPE1) &&  e['type'].includes(TYPE2) &&  e['type'].includes(TYPE3) && !e['type'].includes(TYPE4)){ combos[5]++;}
-    else if( e['type'].includes(TYPE1) &&  e['type'].includes(TYPE2) &&  e['type'].includes(TYPE3) && !e['type'].includes(TYPE4)){ combos[6]++;}
-    else if( e['type'].includes(TYPE1) && !e['type'].includes(TYPE2) && !e['type'].includes(TYPE3) &&  e['type'].includes(TYPE4)){ combos[7]++;}
-    else if(!e['type'].includes(TYPE1) &&  e['type'].includes(TYPE2) && !e['type'].includes(TYPE3) &&  e['type'].includes(TYPE4)){ combos[8]++;}
-    else if(!e['type'].includes(TYPE1) && !e['type'].includes(TYPE2) &&  e['type'].includes(TYPE3) &&  e['type'].includes(TYPE4)){ combos[9]++;}
-    else if( e['type'].includes(TYPE1) &&  e['type'].includes(TYPE2) && !e['type'].includes(TYPE3) &&  e['type'].includes(TYPE4)){ combos[10]++;}
-    else if( e['type'].includes(TYPE1) && !e['type'].includes(TYPE2) &&  e['type'].includes(TYPE3) &&  e['type'].includes(TYPE4)){ combos[11]++;}
-    else if(!e['type'].includes(TYPE1) &&  e['type'].includes(TYPE2) &&  e['type'].includes(TYPE3) &&  e['type'].includes(TYPE4)){ combos[12]++;}
-    else if( e['type'].includes(TYPE1) &&  e['type'].includes(TYPE2) &&  e['type'].includes(TYPE3) &&  e['type'].includes(TYPE4)){ combos[13]++;}
+let candidates = [...dpgs];
 
-    if(e['stage']=='DPG') {
+let combos = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+// Initialize SDG array to count occurences in candidates
+let sdgs = new Array(17).fill(0);
+// Initialize type array to count occurences in candidates
+const TYPE1 = "Open software";
+const TYPE2 = "Open data";
+const TYPE3 = "Open standard";
+const TYPE4 = "Open content";
+let types = {};
+types[TYPE1] = 0;
+types[TYPE2] = 0;
+types[TYPE3] = 0;
+types[TYPE4] = 0;
+let vettedDPGs = 0;
+
+// Iterate over candidates, and over each nested array and count
+candidates.forEach(function (e) {
+  /* if (!e["sdgs"]) {
+    console.log(e)
+  } */
+  if (e["sdgs"]) {
+    e["sdgs"].forEach(function (d) {
+      let goalString = SDGS.find((goal,index)=>goal.includes(d.sdg.substring(3,5)))
+      let sdgNumber = SDGS.indexOf(goalString);
+      //console.log(d.sdg+" The SDG number is ", sdgNumber)
+      //sdgs[d["SDGNumber"] - 1]++;
+      sdgs[sdgNumber]++;
+
+    });
+    console.log(sdgs)
+    if (e["categories"]) {
+      e["categories"].forEach(function (d) {
+        types[d]++;
+      });
+      
+      if (
+        e["categories"].includes(TYPE1) &&
+        !e["categories"].includes(TYPE2) &&
+        !e["categories"].includes(TYPE3) &&
+        !e["categories"].includes(TYPE4)
+      ) {
+        combos[0]++;
+      } else if (
+        !e["categories"].includes(TYPE1) &&
+        e["categories"].includes(TYPE2) &&
+        !e["categories"].includes(TYPE3) &&
+        !e["categories"].includes(TYPE4)
+      ) {
+        combos[1]++;
+      } else if (
+        !e["categories"].includes(TYPE1) &&
+        !e["categories"].includes(TYPE2) &&
+        e["categories"].includes(TYPE3) &&
+        !e["categories"].includes(TYPE4)
+      ) {
+        combos[2]++;
+      } else if (
+        e["categories"].includes(TYPE1) &&
+        e["categories"].includes(TYPE2) &&
+        !e["categories"].includes(TYPE3) &&
+        !e["categories"].includes(TYPE4)
+      ) {
+        combos[3]++;
+      } else if (
+        e["categories"].includes(TYPE1) &&
+        !e["categories"].includes(TYPE2) &&
+        e["categories"].includes(TYPE3) &&
+        !e["categories"].includes(TYPE4)
+      ) {
+        combos[4]++;
+      } else if (
+        !e["categories"].includes(TYPE1) &&
+        e["categories"].includes(TYPE2) &&
+        e["categories"].includes(TYPE3) &&
+        !e["categories"].includes(TYPE4)
+      ) {
+        combos[5]++;
+      } else if (
+        e["categories"].includes(TYPE1) &&
+        e["categories"].includes(TYPE2) &&
+        e["categories"].includes(TYPE3) &&
+        !e["categories"].includes(TYPE4)
+      ) {
+        combos[6]++;
+      } else if (
+        e["categories"].includes(TYPE1) &&
+        !e["categories"].includes(TYPE2) &&
+        !e["categories"].includes(TYPE3) &&
+        e["categories"].includes(TYPE4)
+      ) {
+        combos[7]++;
+      } else if (
+        !e["categories"].includes(TYPE1) &&
+        e["categories"].includes(TYPE2) &&
+        !e["categories"].includes(TYPE3) &&
+        e["categories"].includes(TYPE4)
+      ) {
+        combos[8]++;
+      } else if (
+        !e["categories"].includes(TYPE1) &&
+        !e["categories"].includes(TYPE2) &&
+        e["categories"].includes(TYPE3) &&
+        e["categories"].includes(TYPE4)
+      ) {
+        combos[9]++;
+      } else if (
+        e["categories"].includes(TYPE1) &&
+        e["categories"].includes(TYPE2) &&
+        !e["categories"].includes(TYPE3) &&
+        e["categories"].includes(TYPE4)
+      ) {
+        combos[10]++;
+      } else if (
+        e["categories"].includes(TYPE1) &&
+        !e["categories"].includes(TYPE2) &&
+        e["categories"].includes(TYPE3) &&
+        e["categories"].includes(TYPE4)
+      ) {
+        combos[11]++;
+      } else if (
+        !e["categories"].includes(TYPE1) &&
+        e["categories"].includes(TYPE2) &&
+        e["categories"].includes(TYPE3) &&
+        e["categories"].includes(TYPE4)
+      ) {
+        combos[12]++;
+      } else if (
+        e["categories"].includes(TYPE1) &&
+        e["categories"].includes(TYPE2) &&
+        e["categories"].includes(TYPE3) &&
+        e["categories"].includes(TYPE4)
+      ) {
+        combos[13]++;
+      }
+    }
+    if (e["stage"] == "DPG") {
       vettedDPGs++;
     }
-  })
-
-  // Prepare data for chart
-  let sdgData = { name: 'SDGs', children: []};
-  for(let i=0; i < sdgs.length; i++) {
-    if (sdgs[i]) {
-      sdgData['children'].push({name: i+1, value: sdgs[i]});
-    }
   }
+});
 
-  var sets = [
-                {sets: [1], size: types[TYPE1], value: types[TYPE1], label: TYPE1},
-                {sets: [2], size: types[TYPE2], value: types[TYPE2], label: TYPE2},
-                {sets: [3], size: types[TYPE3], value: types[TYPE3], label: TYPE3},
-                {sets: [4], size: types[TYPE4], value: types[TYPE4], label: TYPE4},
-                {sets: [1, 2], size: combos[3], value: combos[3]},
-                {sets: [1, 3], size: combos[4], value: combos[4]},
-                {sets: [1, 4], size: combos[7], value: combos[7]},
-                {sets: [2, 3], size: combos[5], value: combos[5]},
-                {sets: [2, 4], size: combos[8], value: combos[8]},
-                {sets: [3, 4], size: combos[9], value: combos[9]},
-                {sets: [1, 2, 3], size: combos[6], value: combos[6]},
-                {sets: [1, 2, 4], size: combos[10], value: combos[10]},
-                {sets: [1, 3, 4], size: combos[11], value: combos[11]},
-                {sets: [2, 3 ,4], size: combos[12], value: combos[12]},
-                {sets: [1, 2, 3, 4], size: combos[13], value: combos[13]}
-                ];
-
-  // Add total for types to get percentages below
-  let t = 0;
-  for(var key in types){
-    t += types[key];
+// Prepare data for chart
+let sdgData = { name: "sdgs", children: [] };
+for (let i = 0; i < sdgs.length; i++) {
+  if (sdgs[i]) {
+    sdgData["children"].push({ name: i + 1, value: sdgs[i] });
   }
+}
 
-  // Compute type as percetage
-  let type = {};
-  for (var key in types) {
-    type[key]=Math.round(types[key]/t*100);
-  }
+var sets = [
+  { sets: [1], size: types[TYPE1], value: types[TYPE1], label: TYPE1 },
+  { sets: [2], size: types[TYPE2], value: types[TYPE2], label: TYPE2 },
+  { sets: [3], size: types[TYPE3], value: types[TYPE3], label: TYPE3 },
+  { sets: [4], size: types[TYPE4], value: types[TYPE4], label: TYPE4 },
+  { sets: [1, 2], size: combos[3], value: combos[3] },
+  { sets: [1, 3], size: combos[4], value: combos[4] },
+  { sets: [1, 4], size: combos[7], value: combos[7] },
+  { sets: [2, 3], size: combos[5], value: combos[5] },
+  { sets: [2, 4], size: combos[8], value: combos[8] },
+  { sets: [3, 4], size: combos[9], value: combos[9] },
+  { sets: [1, 2, 3], size: combos[6], value: combos[6] },
+  { sets: [1, 2, 4], size: combos[10], value: combos[10] },
+  { sets: [1, 3, 4], size: combos[11], value: combos[11] },
+  { sets: [2, 3, 4], size: combos[12], value: combos[12] },
+  { sets: [1, 2, 3, 4], size: combos[13], value: combos[13] },
+];
 
-  let typeData = [];
-  for (var key in types) {
-    typeData.push({name: key, value: Math.round(types[key]/t*100) });
-  }
+// Add total for types to get percentages below
+let t = 0;
+for (var key in types) {
+  t += types[key];
+}
 
-let htmlOutput = '<div class="row wp-block-buttons is-content-justification-center">';
-htmlOutput += '<div class="col-xs-2 col-xs-offset-1"><span class="big-details">'+candidates.length+'</span><span class="small-title">nominees</span></div>'
-htmlOutput += '<div class="col-xs-1"><img src="https://dpg-website.s3.amazonaws.com/img/right-arrows.svg" style="height:50px; margin-top:20px; display:block"></div>'
-htmlOutput += '<div class="col-xs-2"><span class="big-details">'+vettedDPGs+'</span><span class="small-title">Digital<br/>Public<br/>Goods</span></div>'
-htmlOutput += '<div class="col-xs-4" id="venn"><span class="small-title">distribution by type</span></div></div>'
-htmlOutput += '<div class="row wp-block-buttons is-content-justification-center" style="margin-bottom:5em"><div class="col-xs-10" id="treemap"><span class="small-title">distribution by SDG</span><div id="treemap"></div></div>';
-htmlOutput += '</div>';
+// Compute type as percetage
+let type = {};
+for (var key in types) {
+  type[key] = Math.round((types[key] / t) * 100);
+}
 
-htmlOutput += `
+let typeData = [];
+for (var key in types) {
+  typeData.push({ name: key, value: Math.round((types[key] / t) * 100) });
+}
+
+let htmlOutput =
+  '<div id="topDistributionRow" class="row wp-block-buttons is-content-justification-center">';
+/* 
+  htmlOutput +=
+  '<div class="col-xs-2 col-xs-offset-1"><span class="big-details">' +
+  candidates.length +
+  '</span><span class="small-title">nominees</span></div>';
+htmlOutput +=
+  '<div class="col-xs-1"><img src="https://dpg-website.s3.amazonaws.com/img/right-arrows.svg" style="height:50px; margin-top:20px; display:block"></div>';
+  */
+  htmlOutput +=
+  '<div class="col-xs-2"><span class="big-details">' +
+  vettedDPGs +
+  '</span><span class="small-title">Digital<br/>Public<br/>Goods</span></div>';
+htmlOutput +=
+  '<div class="col-xs-4" id="venn"><span class="small-title">distribution by type</span></div></div>';
+htmlOutput +=
+  '<div class="row wp-block-buttons is-content-justification-center" style="margin-bottom:5em"><div class="col-xs-10" id="treemap"><span class="small-title">distribution by SDG</span><div id="treemap"></div></div>';
+htmlOutput += "</div>";
+
+htmlOutput += ` 
 
 <!-- Load d3.js -->
 <script src="https://d3js.org/d3.v4.js" charset="utf-8"></script>
@@ -169,12 +288,12 @@ var svg = d3.select("#treemap")
 .append("svg")
   .attr("preserveAspectRatio", "xMinYMin meet")
   .attr("viewBox", "0 0 " + width + " " + height)
-`
-htmlOutput += 'var data_sdg = '+JSON.stringify(sdgData)+';';
-htmlOutput += 'var data_type = '+JSON.stringify(typeData)+';';
-htmlOutput += 'var sdg_labels = '+JSON.stringify(SDGS)+';';
-htmlOutput += 'var sdg_colors = '+JSON.stringify(sdgColors)+';';
-htmlOutput += 'var sets = '+JSON.stringify(sets)+';';
+`;
+htmlOutput += "var data_sdg = " + JSON.stringify(sdgData) + ";";
+htmlOutput += "var data_type = " + JSON.stringify(typeData) + ";";
+htmlOutput += "var sdg_labels = " + JSON.stringify(SDGS) + ";";
+htmlOutput += "var sdg_colors = " + JSON.stringify(sdgColors) + ";";
+htmlOutput += "var sets = " + JSON.stringify(sets) + ";";
 
 htmlOutput += `
 
@@ -237,7 +356,7 @@ htmlOutput += `
 textLine.each(function (d) {
   var fullText = sdg_labels[d.data.name - 1] + ": " + d.data.value;
   // add label of values to the first element
-  d.data.name == 1 ? (fullText += " nominees") : null;
+  d.data.name == 1 ? (fullText += " DPGs") : null;
 
   var rectWidth = d.x1 - d.x0;
   var rectHeight = d.y1 - d.y0;
@@ -323,7 +442,7 @@ textLine.each(function (d) {
     tool.style("left", d3.event.pageX + 10 + "px")
     tool.style("top", d3.event.pageY - 20 + "px")
     tool.style("display", "inline-block");
-    tool.html('SDG '+d.data.name+': '+sdg_labels[d.data.name-1]+'<br/>'+d.data.value+' nominees');
+    tool.html('SDG '+d.data.name+': '+sdg_labels[d.data.name-1]+'<br/>'+d.data.value+' DPGs');
   }
 
   function handleMouseOut(d, i) {
@@ -378,7 +497,7 @@ textLine.each(function (d) {
     tool.style("left", d3.event.pageX + 10 + "px")
     tool.style("top", d3.event.pageY - 20 + "px")
     tool.style("display", "inline-block");
-    tool.html(d.value+' nominees');
+    tool.html(d.value+' DPGs');
   }
 
   function handleVennMouseOut(d, i) {
@@ -400,7 +519,7 @@ textLine.each(function (d) {
 
 `;
 
-  htmlOutput += `
+htmlOutput += `
     <div id="main-content" class="container clearfix" style="position: relative">
       <div id="sidebar">
         <div class="sidebar__inner" id="filters" style="position:relative">
@@ -415,7 +534,7 @@ textLine.each(function (d) {
     </div>
 `;
 
-  const endHtml = `
+const endHtml = `
   <script type="text/javascript" src="./ResizeSensor.js"></script>
     <script type='text/javascript' src="./sticky-sidebar.min.js"></script>
 
@@ -428,58 +547,81 @@ textLine.each(function (d) {
        });
     </script>
   </body>
-  `
-  let formHtmlOutput = '<div id="form-content"> </div>';
+  `;
+let formHtmlOutput = '<div id="form-content"> </div>';
 
-  replace({files: pathHtml, from: '<p>Placeholder</p>', to: htmlOutput}, (error, changedFiles) => {
+replace(
+  { files: pathHtml, from: "<p>Placeholder</p>", to: htmlOutput },
+  (error, changedFiles) => {
     if (error) {
-      return console.error('Error occurred:', error);
+      return console.error("Error occurred:", error);
     }
-    console.log('Modified files:', changedFiles.join(', '));
+    console.log("Modified files:", changedFiles.join(", "));
 
-    replace({files: pathHtml, from: 'class="col-md-8 page-content-wrap  col-md-offset-2"', to: 'class="col-lg-12 page-content-wrap"'}, (error, changedFiles) => {
-      if (error) {
-        return console.error('Error occurred:', error);
-      }
-      console.log('Modified files:', changedFiles.join(', '));
-
-      replace({files: pathHtml, from: '</body>', to: endHtml}, (error, changedFiles) => {
+    replace(
+      {
+        files: pathHtml,
+        from: 'class="col-md-8 page-content-wrap  col-md-offset-2"',
+        to: 'class="col-lg-12 page-content-wrap"',
+      },
+      (error, changedFiles) => {
         if (error) {
-          return console.error('Error occurred:', error);
+          return console.error("Error occurred:", error);
         }
+        console.log("Modified files:", changedFiles.join(", "));
 
-        fs.copyFileSync(pathHtml, destHtml);
+        replace(
+          { files: pathHtml, from: "</body>", to: endHtml },
+          (error, changedFiles) => {
+            if (error) {
+              return console.error("Error occurred:", error);
+            }
 
-      });
-    });
-  });
+            fs.copyFileSync(pathHtml, destHtml);
+          }
+        );
+      }
+    );
+  }
+);
 
-  replace({files: pathFormHtml, from: '<p>Placeholder</p>', to: formHtmlOutput}, (error, changedFiles) => {
+replace(
+  { files: pathFormHtml, from: "<p>Placeholder</p>", to: formHtmlOutput },
+  (error, changedFiles) => {
     if (error) {
-      return console.error('Error occurred:', error);
+      return console.error("Error occurred:", error);
     }
-    console.log('Modified files:', changedFiles.join(', '));
+    console.log("Modified files:", changedFiles.join(", "));
     fs.copyFileSync(pathFormHtml, destFormHtml);
-  });
+  }
+);
 
-  replace({files: pathRoadmapHtml, from: '<p>Placeholder</p>', to: formHtmlOutput}, (error, changedFiles) => {
+replace(
+  { files: pathRoadmapHtml, from: "<p>Placeholder</p>", to: formHtmlOutput },
+  (error, changedFiles) => {
     if (error) {
-      return console.error('Error occurred:', error);
+      return console.error("Error occurred:", error);
     }
-    console.log('Modified files:', changedFiles.join(', '));
+    console.log("Modified files:", changedFiles.join(", "));
     fs.copyFileSync(pathRoadmapHtml, destRoadmapHtml);
-  });
+  }
+);
 
-  fs.readFile(pathMapHtml,'utf8',  function (err, html) {
-    if (err) {
-      return console.error('Error occurred:', err);
-    }
-    let $ = cheerio.load(html);
-    $('main').remove(); // removes element where map will be placed 
-    fs.writeFileSync(destMapHtml + 'head.html', $("head").html())
-    fs.writeFileSync(destMapHtml + 'footer.html', $("footer").html())
-    fs.writeFileSync(destMapHtml + 'scripts.html', $.html($("#dpga-libs-js")) + $.html($("#dpga-main-js"))) // finds specific dpga scripts.
-    fs.writeFileSync(destMapHtml + 'navbar.html', $("#page").html())
-    fs.writeFileSync(destMapHtml + 'templateClassName.txt', $("body").attr('class'))
-  });    
-})
+fs.readFile(pathMapHtml, "utf8", function (err, html) {
+  if (err) {
+    return console.error("Error occurred:", err);
+  }
+  let $ = cheerio.load(html);
+  $("main").remove(); // removes element where map will be placed
+  fs.writeFileSync(destMapHtml + "head.html", $("head").html());
+  fs.writeFileSync(destMapHtml + "footer.html", $("footer").html());
+  fs.writeFileSync(
+    destMapHtml + "scripts.html",
+    $.html($("#dpga-libs-js")) + $.html($("#dpga-main-js"))
+  ); // finds specific dpga scripts.
+  fs.writeFileSync(destMapHtml + "navbar.html", $("#page").html());
+  fs.writeFileSync(
+    destMapHtml + "templateClassName.txt",
+    $("body").attr("class")
+  );
+});

--- a/packages/automation/index.js
+++ b/packages/automation/index.js
@@ -356,7 +356,7 @@ htmlOutput += `
 textLine.each(function (d) {
   var fullText = sdg_labels[d.data.name - 1] + ": " + d.data.value;
   // add label of values to the first element
-  d.data.name == 1 ? (fullText += " DPGs") : null;
+  d.data.name == 1 ? (fullText += " DPGs") : "null";
 
   var rectWidth = d.x1 - d.x0;
   var rectHeight = d.y1 - d.y0;
@@ -442,7 +442,7 @@ textLine.each(function (d) {
     tool.style("left", d3.event.pageX + 10 + "px")
     tool.style("top", d3.event.pageY - 20 + "px")
     tool.style("display", "inline-block");
-    tool.html('SDG '+d.data.name+': '+sdg_labels[d.data.name-1]+'<br/>'+d.data.value+' DPGs');
+    tool.html(sdg_labels[d.data.name-1]+'<br/>'+d.data.value+' DPGs');
   }
 
   function handleMouseOut(d, i) {


### PR DESCRIPTION
This PR:

- Refactors the Data Explorer section of the DPG website to point to the new review webapp's API.
- Removes mention of registry in the distribution chart output and Venn diagram

Note:
- Since the data is now pulling only DPG from the API instead of nominees like before, a few values in the chart may change from before either by increasing or decreasing.

ToDo:
- Alter the language of the registry page to remove mention of `nominees` in a number of the page's paragraphs.