### PR TITLE
HotFix: Temporarily removing map package

### DIFF
--- a/.github/workflows/auto.yml
+++ b/.github/workflows/auto.yml
@@ -12,9 +12,9 @@ jobs:
         with:
           node-version: '16'
       - name: Clone publicgoods-website
-        run: git clone https://github.com/unicef/publicgoods-website.git ../publicgoods-website
+        run: git clone https://github.com/DPGAlliance/publicgoods-website.git ../publicgoods-website
       - name: Clone publicgoods-candidates
-        run: git clone https://github.com/unicef/publicgoods-candidates.git ../publicgoods-candidates
+        run: git clone https://github.com/DPGAlliance/publicgoods-candidates.git ../publicgoods-candidates
       - name: Run static.bash
         run: bash scripts/static.bash
       # - name: Generating DPG's

--- a/.github/workflows/auto.yml
+++ b/.github/workflows/auto.yml
@@ -46,11 +46,11 @@ jobs:
         run: cd packages/eligibility && npm install && npm run build
       - name: Build packages/registry
         run: cd packages/registry && npm install && npm run build
-      - name: Build packages/map
-        run: cd packages/map && npm install && npm run build
-        env:
-          NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.NEXT_PUBLIC_MAPBOX_TOKEN }}
-          NEXT_PUBLIC_SHEET_ID: ${{ secrets.NEXT_PUBLIC_SHEET_ID }}
+      #- name: Build packages/map
+      #  run: cd packages/map && npm install && npm run build
+      #  env:
+      #    NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.NEXT_PUBLIC_MAPBOX_TOKEN }}
+      #    NEXT_PUBLIC_SHEET_ID: ${{ secrets.NEXT_PUBLIC_SHEET_ID }}
       - name: Build packages/roadmap
         run: cd packages/roadmap && npm install && npm run build
       - name: Run moveFiles.bash


### PR DESCRIPTION
One part of of the problem of currently failing builds is that the maps package is broken. 
This may be due to old legacy code and dependencies being updated or depricated. 

As such I am temporarily disabling it in the build to allowthe registry page to be compiled.

This means that links to the DPG map will return a 404 error.